### PR TITLE
ARG-DB-200: setup reading history data sets

### DIFF
--- a/argusApp/app/Http/Controllers/Api/SensorController.php
+++ b/argusApp/app/Http/Controllers/Api/SensorController.php
@@ -15,7 +15,9 @@ class SensorController extends Controller
      */
     public function index()
     {
-        //
+        $sensorData = Sensor::all();
+
+        return response()->json($sensorData);
     }
 
     /**
@@ -87,6 +89,106 @@ class SensorController extends Controller
      */
     public function destroy($id)
     {
-        //
+
     }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function compress()
+    {
+        $sensorData = Sensor::where('type', 1)->get();
+
+        $datesArr = [];
+
+        $compressedArr = [];
+
+        // $moistureArr = [];
+        // $lightArr = [];
+        // $tempArr = [];
+        // $gasArr = [];
+
+        foreach ($sensorData as $item) {
+            //checks to see if sensor values are older than 2 days
+            //explanation: gets current time, minus the time at which the item was recorded
+            //checks if the item is older than two days (2 * seconds in a day)
+
+            $dateform = date('Y-m-d', strtotime($item->recorded_at));
+
+            if(date('Y-m-d', time()) != $dateform) {
+                //if the above is true, pushes the record to sensorArrOldData
+
+                //if date is in datesArr,
+                //then loop through the compressedDays array and if the recorded_at attribute
+                //is equal to date, push the items into the sensor data array;
+                if (in_array($dateform, $datesArr)) {
+
+                    foreach ($compressedArr as $day) {
+
+                        if ($day->recorded_at == $dateform) {
+                            $day->moistureArr[] = $item->moisture;
+                            $day->lightArr[] = $item->light;
+                            $day->tempArr[] = $item->temp;
+                            $day->gasArr[] = $item->gas;
+                        }
+                    }
+
+                //if dat is NOT in datesArr,
+                //then create an array like you would push to the database,
+                //except keep make the sensor data equal to an array containing
+                //the sensor data
+                //finally, push the date to the datesArr
+                } else {
+
+                    $newDay = new \stdClass();
+                    $newDay->moistureArr = [$item->moisture];
+                    $newDay->lightArr = [$item->light];
+                    $newDay->tempArr = [$item->temp];
+                    $newDay->gasArr = [$item->gas];
+                    $newDay->recorded_at = $dateform;
+
+
+                    $compressedArr[] = $newDay;
+                    $datesArr[] = $dateform;
+
+                }
+
+                if (time() - strtotime($item->recorded_at) > 86400) {
+                    $item->delete();
+                }
+            }
+        }
+
+        if (count($datesArr) > 0) {
+
+            foreach ($compressedArr as $day) {
+
+            $moisture = round(array_sum($day->moistureArr)/count($day->moistureArr));
+            $light = round(array_sum($day->lightArr)/count($day->lightArr));
+            $temp = round(array_sum($day->tempArr)/count($day->tempArr));
+            $gas = round(array_sum($day->gasArr)/count($day->gasArr));
+
+            $compression = Sensor::create([
+                'moisture' => $moisture,
+                'light' => $light,
+                'temp' => $temp,
+                'gas' => $gas,
+                'type' => 2,
+                'recorded_at' => $day->recorded_at,
+            ]);
+
+            $compression->save();
+        }
+        } else {
+            $compression = false;
+        }
+
+
+        return response()->json($compression);
+    }
+
+
 }

--- a/argusApp/app/Sensor.php
+++ b/argusApp/app/Sensor.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
+
 class Sensor extends Model
 {
 
@@ -24,19 +25,12 @@ class Sensor extends Model
      * @var array
      */
     protected $fillable = [
-        'user_id',
         'moisture',
         'light',
         'temp',
-        'gas'
+        'gas',
+        'type',
+        'recorded_at'
     ];
 
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'recorded_at' => 'datetime',
-    ];
 }

--- a/argusApp/database/factories/SensorFactory.php
+++ b/argusApp/database/factories/SensorFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Sensor;
+use Faker\Generator as Faker;
+use Carbon\Carbon;
+
+$factory->define(Sensor::class, function (Faker $faker) {
+
+
+    $today = Carbon::now()->timestamp;
+
+    return [
+        'moisture' => random_int(50, 99),
+        'light'=> random_int(50, 99),
+        'temp' => random_int(68, 72),
+        'gas' => random_int(50, 99),
+        'type' => 1,
+        'recorded_at' => date("Y-m-d H:i:s", mt_rand(strtotime('today - 30 days'), $today))
+    ];
+});

--- a/argusApp/database/migrations/2022_03_25_163354_create_sensors_table.php
+++ b/argusApp/database/migrations/2022_03_25_163354_create_sensors_table.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateSensorsTable extends Migration
 {
+
     /**
      * Run the migrations.
      *
@@ -16,11 +17,11 @@ class CreateSensorsTable extends Migration
         Schema::create('sensors', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->timestamps();
-            $table->string('user_id');
             $table->integer('moisture');
             $table->integer('light');
             $table->integer('temp');
             $table->integer('gas');
+            $table->integer('type')->default(1);
             $table->timestamp('recorded_at')->useCurrent();
         });
     }

--- a/argusApp/database/seeds/DatabaseSeeder.php
+++ b/argusApp/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call([SensorTableSeeder::class]);
     }
 }

--- a/argusApp/database/seeds/SensorTableSeeder.php
+++ b/argusApp/database/seeds/SensorTableSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Sensor;
+use Illuminate\Database\Eloquent\Model;
+
+class SensorTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(Sensor::class, 1000)->create();
+    }
+}

--- a/argusApp/resources/js/app.js
+++ b/argusApp/resources/js/app.js
@@ -30,6 +30,15 @@ const store = new Vuex.Store({
             gas: [],
             temp: [],
         },
+        dayTrend: [],
+        monthTrend: [],
+        sensorValues: {
+            increment: 0,
+            light: [],
+            moisture: [],
+            gas: [],
+            temp: [],
+        },
         currentReading: {
             light: 'reading data..',
             moisture: 'reading data..',
@@ -47,6 +56,8 @@ const store = new Vuex.Store({
             state.sensorValues.moisture.push(myCustomData.moisture);
             state.sensorValues.gas.push(myCustomData.gas);
             state.sensorValues.temp.push(myCustomData.temp);
+
+            state.currentReading = myCustomData;
         },
         sensorValueReset (state) {
             state.sensorValues.increment = 0;
@@ -55,8 +66,11 @@ const store = new Vuex.Store({
             state.sensorValues.gas = [];
             state.sensorValues.temp = [];
         },
-        currentReading (state, myCustomData) {
-            state.currentReading = myCustomData
+        dayTrend (state, myCustomData) {
+            state.dayTrend = myCustomData;
+        },
+        monthTrend (state, myCustomData) {
+            state.monthTrend = myCustomData;
         }
     }
 });

--- a/argusApp/resources/js/components/App.vue
+++ b/argusApp/resources/js/components/App.vue
@@ -28,6 +28,51 @@
 
 
         methods: {
+
+            pullSensorData() {
+
+                let dayTrendArr = [];
+                let monthTrendArr = [];
+
+                 axios.get('/api/sensors')
+                    .then(response => {
+                        console.log('all data', response.data);
+                        response.data.forEach(item => {
+                            if (item.type === 1) {
+                                dayTrendArr.push(item);
+                            } else if (item.type === 2) {
+                                monthTrendArr.push(item);
+                            };
+                        })
+                    })
+                    .then(() => {
+                        console.log('check Arr', monthTrendArr)
+                        if (dayTrendArr.length > 0) {
+                            this.$store.commit('dayTrend', dayTrendArr);
+                        }
+                        if (monthTrendArr.length > 0) {
+                              this.$store.commit('monthTrend', monthTrendArr);
+                        }
+                    }).catch(error => {
+                        console.log(error);
+                    });
+            },
+
+            compressPastData() {
+
+                const formData = new FormData();
+                formData.append('_method', 'PATCH');
+
+                axios.post('/api/sensors/compress', formData)
+                    .then(response => {
+                        console.log('check', response.data);
+                    }).then(() => {
+                        this.pullSensorData();
+                    }).catch(error => {
+                        console.log(error);
+                    });
+            },
+
             storeAverageValues() {
                 //average store sensor data
 
@@ -46,16 +91,13 @@
                 formData.append('light', light);
                 formData.append('temp', temp);
                 formData.append('gas', gas);
-                formData.append('user_id', this.user.id);
                 // formData.append('plant_id', 1); leave this out for now, ask marco what approach is best for generating different data for different plants
                 //method 1 -> can just use a transformer to change the data when it is being retrieved based on plant id provided
                 //method
 
                  axios.post('/api/sensors', formData)
                     .then(response => {
-                        return response.data;
-                    }).then(data => {
-                        this.$store.commit('currentReading', data);
+                        console.log(response.data);
                     }).catch(error => {
                         console.log(error);
                     });
@@ -77,6 +119,8 @@
         mounted() {
 
             this.$store.commit('user', this.user);
+
+            this.compressPastData();
 
             let t = this;
 
@@ -101,7 +145,7 @@
                 //temp
                 let val =  snapshot.val().temp.value;
                 let tempF = val.replace(/\D/g, '');
-                let tempC = Math.round(tempF * 9 / 5 + 32);
+                let tempC = Math.round((tempF-32)/1.8);
                 sensorSnap.temp = tempC;
 
                 //moisture

--- a/argusApp/resources/js/components/PlantView.vue
+++ b/argusApp/resources/js/components/PlantView.vue
@@ -9,6 +9,30 @@
             <p>Temperature: {{sensor.temp}} degrees celcius</p><br/>
 
         <button @click="togglePlantInfo">More Plant Info</button>
+        <div style="float: left;">
+            <h2>24 HOUR TREND</h2>
+            <ul v-if="dayTrend">
+                <li v-for="data in dayTrend" :key="data.id">
+                    <p>Light: {{data.light}}</p><br/>
+                    <p>Moisture: {{data.moisture}}</p><br/>
+                    <p>Gas: {{data.gas}}</p><br/>
+                    <p>Temperature: {{data.temp}} degrees celcius</p><br/>
+                    <p>Time: {{data.recorded_at}}</p><br/>
+                </li>
+            </ul>
+        </div>
+        <div style="float: right;">
+        <h2>30 DAY TREND</h2>
+            <ul v-if="monthTrend">
+                <li v-for="data in monthTrend" :key="data.id">
+                    <p>Light: {{data.light}}</p><br/>
+                    <p>Moisture: {{data.moisture}}</p><br/>
+                    <p>Gas: {{data.gas}}</p><br/>
+                    <p>Temperature: {{data.temp}} degrees celcius</p><br/>
+                    <p>Time: {{data.recorded_at}}</p><br/>
+                </li>
+            </ul>
+        </div>
     </div>
 </template>
 
@@ -27,6 +51,22 @@
         computed: {
             sensor() {
                 return this.$store.state.currentReading;
+            },
+            dayTrend() {
+                let dayTrendData = this.$store.state.dayTrend;
+                if (dayTrendData.length > 0) {
+                    return dayTrendData;
+                } else {
+                    return false;
+                }
+            },
+            monthTrend() {
+                let monthTrendData = this.$store.state.monthTrend;
+                if (monthTrendData.length > 0) {
+                    return monthTrendData;
+                } else {
+                    return false;
+                }
             }
         },
 

--- a/argusApp/resources/js/router/index.js
+++ b/argusApp/resources/js/router/index.js
@@ -9,6 +9,10 @@ Vue.use(Router);
 export default new Router({
     routes: [
         {
+            path: '/',
+            redirect: '/home'
+        },
+        {
             path: '/home',
             name: 'home',
             component: Home

--- a/argusApp/routes/api.php
+++ b/argusApp/routes/api.php
@@ -19,4 +19,10 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::patch('users/{user}', 'Api\UserController@update')->name('users.update');
 
+
+//sensor data
 Route::post('sensors', 'Api\SensorController@store')->name('sensors.store');
+
+Route::get('sensors', 'Api\SensorController@index')->name('sensors.index');
+
+Route::patch('sensors/compress', 'Api\SensorController@compress')->name('sensors.compress');


### PR DESCRIPTION
-created a seeder/factory that populates 1000 random data points from within the last 30 days.
-on mount, all records (except for those occurring on the current date) are grouped by day and the sensor data from each day is averaged to create a new 'type 2' record that summarizes the data on each day. All individual data points older than 24 hours are then deleted.
-TLDR: we now have a dataset for each day in the past 30 days, and a dataset for all readings over the course of the last 24 hours.
to run seeders:
1) docker-compose run artisan migrate:rollback
2) docker-compose run artisan migrate
3) docker-compose run artisan db:seed
OR 
1) docker-compose run artisan migrate:fresh --seed